### PR TITLE
Update to iqm-client 4.2 and replace settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 obj
 docs/extensions
 .ipynb_checkpoints
+pytket/extensions/iqm/_metadata.py

--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.4.1rc0"
+__extension_version__ = "0.5.0"
 __extension_name__ = "pytket-iqm"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 ~~~~~~~~~
 
+0.5.0 (unreleased)
+
+* Updated iqm-client version requirement to 4.2.
+
 0.4.0 (May 2022)
 ----------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@ Changelog
 ~~~~~~~~~
 
 0.5.0 (unreleased)
+------------------
 
 * Updated iqm-client version requirement to 4.2.
 

--- a/pytket/extensions/iqm/backends/iqm.py
+++ b/pytket/extensions/iqm/backends/iqm.py
@@ -239,7 +239,7 @@ class IQMBackend(Backend):
             iqmc = IQMCircuit(
                 name=c.name if c.name else f"circuit_{i}", instructions=instrs
             )
-            run_id = self._client.submit_circuit(iqmc, qm, shots=n_shots)
+            run_id = self._client.submit_circuits([iqmc], qm, shots=n_shots)
             handles.append(ResultHandle(run_id.bytes, json.dumps(ppcirc_rep)))
         for handle in handles:
             self._cache[handle] = dict()

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.4", "iqm-client ~= 3.0"],
+    install_requires=["pytket ~= 1.4", "iqm-client ~= 4.2"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -28,6 +28,8 @@ REASON = "PYTKET_RUN_REMOTE_TESTS not set (requires configuration of IQM credent
 if skip_remote_tests is False and get(get_demo_url()).status_code != 200:
     skip_remote_tests = True
     REASON = "The IQM demo site/service is unavailable"
+skip_remote_tests = True
+REASON = "The IQM demo site/service is unavailable"
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -28,8 +28,6 @@ REASON = "PYTKET_RUN_REMOTE_TESTS not set (requires configuration of IQM credent
 if skip_remote_tests is False and get(get_demo_url()).status_code != 200:
     skip_remote_tests = True
     REASON = "The IQM demo site/service is unavailable"
-skip_remote_tests = True
-REASON = "The IQM demo site/service is unavailable"
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)

--- a/tests/demo_settings.json
+++ b/tests/demo_settings.json
@@ -890,6 +890,16 @@
                 "flux": {
                     "name": "QB1__flux",
                     "settings": {
+                        "target": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Target flux",
+                                "name": "QB1__flux.target",
+                                "unit": "quanta"
+                            },
+                            "value": null
+                        },
                         "voltage": {
                             "parameter": {
                                 "collection_type": 0,
@@ -1754,6 +1764,16 @@
                 "flux": {
                     "name": "QB2__flux",
                     "settings": {
+                        "target": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Target flux",
+                                "name": "QB2__flux.target",
+                                "unit": "quanta"
+                            },
+                            "value": null
+                        },
                         "voltage": {
                             "parameter": {
                                 "collection_type": 0,
@@ -2618,6 +2638,16 @@
                 "flux": {
                     "name": "QB3__flux",
                     "settings": {
+                        "target": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Target flux",
+                                "name": "QB3__flux.target",
+                                "unit": "quanta"
+                            },
+                            "value": null
+                        },
                         "voltage": {
                             "parameter": {
                                 "collection_type": 0,
@@ -3482,6 +3512,16 @@
                 "flux": {
                     "name": "QB4__flux",
                     "settings": {
+                        "target": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Target flux",
+                                "name": "QB4__flux.target",
+                                "unit": "quanta"
+                            },
+                            "value": null
+                        },
                         "voltage": {
                             "parameter": {
                                 "collection_type": 0,
@@ -4346,6 +4386,16 @@
                 "flux": {
                     "name": "QB5__flux",
                     "settings": {
+                        "target": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Target flux",
+                                "name": "QB5__flux.target",
+                                "unit": "quanta"
+                            },
+                            "value": null
+                        },
                         "voltage": {
                             "parameter": {
                                 "collection_type": 0,
@@ -4567,6 +4617,16 @@
                 "flux": {
                     "name": "TC_1_3__flux",
                     "settings": {
+                        "target": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Target flux",
+                                "name": "TC_1_3__flux.target",
+                                "unit": "quanta"
+                            },
+                            "value": null
+                        },
                         "voltage": {
                             "parameter": {
                                 "collection_type": 0,
@@ -5076,6 +5136,16 @@
                 "flux": {
                     "name": "TC_2_3__flux",
                     "settings": {
+                        "target": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Target flux",
+                                "name": "TC_2_3__flux.target",
+                                "unit": "quanta"
+                            },
+                            "value": null
+                        },
                         "voltage": {
                             "parameter": {
                                 "collection_type": 0,
@@ -5585,6 +5655,16 @@
                 "flux": {
                     "name": "TC_3_4__flux",
                     "settings": {
+                        "target": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Target flux",
+                                "name": "TC_3_4__flux.target",
+                                "unit": "quanta"
+                            },
+                            "value": null
+                        },
                         "voltage": {
                             "parameter": {
                                 "collection_type": 0,
@@ -6094,6 +6174,16 @@
                 "flux": {
                     "name": "TC_3_5__flux",
                     "settings": {
+                        "target": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Target flux",
+                                "name": "TC_3_5__flux.target",
+                                "unit": "quanta"
+                            },
+                            "value": null
+                        },
                         "voltage": {
                             "parameter": {
                                 "collection_type": 0,


### PR DESCRIPTION
I tried re-enabling the remote tests but they are still failing, now with errors like:
```
>       res = b.run_circuit(c, n_shots=n_shots, timeout=30)

backend_test.py:49: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../env/lib/python3.9/site-packages/pytket/backends/backend.py:384: in run_circuit
    return self.run_circuits(
../env/lib/python3.9/site-packages/pytket/backends/backend.py:409: in run_circuits
    results = self.get_results(handles, **kwargs)
../env/lib/python3.9/site-packages/pytket/backends/backend.py:352: in get_results
    return [self.get_result(handle, **kwargs) for handle in handles]
../env/lib/python3.9/site-packages/pytket/backends/backend.py:352: in <listcomp>
    return [self.get_result(handle, **kwargs) for handle in handles]
../pytket/extensions/iqm/backends/iqm.py:294: in get_result
    self._client.wait_for_results(run_id, timeout_secs=timeout)
../env/lib/python3.9/site-packages/iqm_client/iqm_client.py:570: in wait_for_results
    results = self.get_run(job_id)
../env/lib/python3.9/site-packages/iqm_client/iqm_client.py:522: in get_run
    result = RunResult.from_dict(result.json())
../env/lib/python3.9/site-packages/iqm_client/iqm_client.py:268: in from_dict
    return RunResult(status=Status(input_copy.pop('status')), **input_copy)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   pydantic.error_wrappers.ValidationError: 1 validation error for RunResult
E   metadata
E     field required (type=value_error.missing)

pydantic/main.py:341: ValidationError
```