### PR TITLE
Add post-routing optimisations for `optimisation_level=2`.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+* Add some additional post-routing optimisations to the default compilation pass for `optimisation_level=2`.
+
 0.9.0 (November 2023)
 ---------------------
 

--- a/pytket/extensions/iqm/backends/iqm.py
+++ b/pytket/extensions/iqm/backends/iqm.py
@@ -39,6 +39,8 @@ from pytket.passes import (
     DefaultMappingPass,
     DelayMeasures,
     SimplifyInitial,
+    KAKDecomposition,
+    CliffordSimp,
 )
 from pytket.predicates import (
     ConnectivityPredicate,
@@ -180,6 +182,10 @@ class IQMBackend(Backend):
             passes.append(FullPeepholeOptimise())
         passes.append(DefaultMappingPass(self._arch))
         passes.append(DelayMeasures())
+        if optimisation_level == 2:
+            passes.append(KAKDecomposition(allow_swaps=False))
+            passes.append(CliffordSimp(allow_swaps=False))
+            passes.append(SynthesiseTket())
         passes.append(self.rebase_pass())
         passes.append(RemoveRedundancies())
         return SequencePass(passes)


### PR DESCRIPTION
Adding in some connectivity preserving "post-routing" optimisations to optimisation level 2 in the default compiler pass.